### PR TITLE
Make plugin compatible with all future IDE versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 0.0.3-EAP
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
-pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # IC = IntelliJ IDEA Community Edition


### PR DESCRIPTION
Fixes https://github.com/Strajk/intellij-plugin-markdownlint/issues/3 by removing any (future) version requirement.

I think, the API of IntelliJ should be stable enough. If users report errors, one can add some constraint.